### PR TITLE
Added Codec definitions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ ThisBuild / licenses := Seq(
   )
 )
 
-ThisBuild / crossScalaVersions := Seq( "3.3.0" )
+ThisBuild / crossScalaVersions := Seq( "3.0.1" )
 
 ThisBuild / scalaVersion := (ThisBuild / crossScalaVersions).value.head
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ ThisBuild / licenses := Seq(
   )
 )
 
-ThisBuild / crossScalaVersions := Seq( "3.0.1" )
+ThisBuild / crossScalaVersions := Seq( "3.3.0" )
 
 ThisBuild / scalaVersion := (ThisBuild / crossScalaVersions).value.head
 

--- a/lib/shared/src/main/scala/org/latestbit/circe/adt/codec/JsonTaggedAdt.scala
+++ b/lib/shared/src/main/scala/org/latestbit/circe/adt/codec/JsonTaggedAdt.scala
@@ -26,6 +26,11 @@ import io.circe.*
 
 object JsonTaggedAdt {
 
+  type Codec[T] = impl.JsonTaggedAdtCodec[T]
+  type CodecWithConfig[T] = impl.JsonTaggedAdtCodecWithConfig[T]
+  type PureCodec[T] = impl.JsonPureTaggedAdtCodec[T]
+  type PureCodecWithConfig[T] = impl.JsonPureTaggedAdtCodecWithConfig[T]
+
   type Encoder[T] = impl.JsonTaggedAdtEncoder[T]
   type EncoderWithConfig[T] = impl.JsonTaggedAdtEncoderWithConfig[T]
   type PureEncoder[T] = impl.JsonPureTaggedAdtEncoder[T]

--- a/lib/shared/src/main/scala/org/latestbit/circe/adt/codec/impl/JsonTaggedAdtCodec.scala
+++ b/lib/shared/src/main/scala/org/latestbit/circe/adt/codec/impl/JsonTaggedAdtCodec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 Abdulla Abdurakhmanov (abdulla@latestbit.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.latestbit.circe.adt.codec.impl
+
+import io.circe.*
+import org.latestbit.circe.adt.codec.*
+
+import scala.compiletime.*
+import scala.deriving.*
+import io.circe.Decoder.Result
+
+sealed trait JsonTaggedAdtCodec[T] extends Decoder[T] with Encoder.AsObject[T]
+sealed trait JsonTaggedAdtCodecWithConfig[T] extends JsonTaggedAdtCodec[T]
+
+sealed trait JsonPureTaggedAdtCodec[T] extends Decoder[T] with Encoder[T]
+sealed trait JsonPureTaggedAdtCodecWithConfig[T] extends JsonPureTaggedAdtCodec[T]
+
+object JsonTaggedAdtCodec {
+
+  inline def createJsonTaggedAdtCodec[T]( using
+      m: Mirror.Of[T],
+      inline adtConfig: JsonTaggedAdt.Config[T]
+  ): JsonTaggedAdtCodec[T] = {
+    val decoder = JsonTaggedAdtDecoder.derived[T]
+    val encoder = JsonTaggedAdtEncoder.derived[T]
+
+    new JsonTaggedAdtCodec[T] {
+      override def encodeObject( obj: T ): JsonObject = encoder.encodeObject( obj )
+      override def apply( cursor: HCursor ): Decoder.Result[T] = decoder.apply( cursor )
+    }
+  }
+
+  implicit inline given derived[T]( using
+      m: Mirror.Of[T],
+      inline adtConfig: JsonTaggedAdt.Config[T] = JsonTaggedAdt.Config.default[T]
+  ): JsonTaggedAdtCodec[T] = createJsonTaggedAdtCodec[T]
+}
+
+object JsonTaggedAdtCodecWithConfig {
+
+  implicit inline given derived[T]( using
+      m: Mirror.Of[T],
+      inline adtConfig: JsonTaggedAdt.Config[T]
+  ): JsonTaggedAdtCodecWithConfig[T] = {
+    val parent = JsonTaggedAdtCodec.derived[T]
+    new JsonTaggedAdtCodecWithConfig[T] {
+      override def encodeObject( a: T ): JsonObject = parent.encodeObject( a )
+      override def apply( c: HCursor ): Decoder.Result[T] = parent.apply( c )
+    }
+  }
+
+}
+
+object JsonPureTaggedAdtCodec {
+
+  implicit inline given derived[T]( using
+      m: Mirror.Of[T],
+      inline adtConfig: JsonTaggedAdt.PureConfig[T] = JsonTaggedAdt.PureConfig.default[T]
+  ): JsonPureTaggedAdtCodec[T] = {
+    val decoder = JsonPureTaggedAdtDecoder.derived[T]
+    val encoder = JsonPureTaggedAdtEncoder.derived[T]
+    new JsonPureTaggedAdtCodec[T] {
+      override def apply( a: T ): Json = encoder.apply( a )
+      override def apply( c: HCursor ): Result[T] = decoder.apply( c )
+    }
+  }
+}
+
+object JsonPureTaggedAdtCodecWithConfig {
+
+  implicit inline given derived[T]( using
+      m: Mirror.Of[T],
+      inline adtConfig: JsonTaggedAdt.PureConfig[T]
+  ): JsonPureTaggedAdtCodecWithConfig[T] = {
+    val parent = JsonPureTaggedAdtCodec.derived[T]
+    new JsonPureTaggedAdtCodecWithConfig[T] {
+      override def apply( c: HCursor ): Result[T] = parent.apply( c )
+      override def apply( obj: T ): Json = parent.apply( obj )
+    }
+  }
+
+}

--- a/lib/shared/src/test/scala/org/latestbit/circe/adt/codec/tests/JsonTaggedAdtCodecImplTestSuite.scala
+++ b/lib/shared/src/test/scala/org/latestbit/circe/adt/codec/tests/JsonTaggedAdtCodecImplTestSuite.scala
@@ -23,12 +23,12 @@ import org.latestbit.circe.adt.codec.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-enum TestModelWithDefaults derives JsonTaggedAdt.Encoder, JsonTaggedAdt.Decoder {
+enum TestModelWithDefaults derives JsonTaggedAdt.Codec {
   case Event1
   case Event2( f1: String )
 }
 
-enum TestModelWithConfig derives JsonTaggedAdt.EncoderWithConfig, JsonTaggedAdt.DecoderWithConfig {
+enum TestModelWithConfig derives JsonTaggedAdt.CodecWithConfig {
   case Event1
   case Event2( f1: String )
 }
@@ -40,16 +40,14 @@ given JsonTaggedAdt.Config[TestModelWithConfig] = JsonTaggedAdt.Config.Values[Te
   )
 )
 
-enum TestModelPure derives JsonTaggedAdt.PureEncoder, JsonTaggedAdt.PureDecoder {
+enum TestModelPure derives JsonTaggedAdt.PureCodec {
   case Event1
   case Event2
 }
 
 case class TestModelWithPure( pure: TestModelPure ) derives Encoder.AsObject, Decoder
 
-enum TestModelPureConfig
-    derives JsonTaggedAdt.PureEncoderWithConfig,
-      JsonTaggedAdt.PureDecoderWithConfig {
+enum TestModelPureConfig derives JsonTaggedAdt.PureCodecWithConfig {
   case Event1
   case Event2
 }


### PR DESCRIPTION
I unified the traits to be able to derive a `Codec`,`CodecWithConfig`,`PureCodec` or `PureCodecWithConfig` directly.
Hope to see it in 0.10.2 too ;)
Closes #1